### PR TITLE
[fix] カレンダーページ-デプロイ時エラー修正

### DIFF
--- a/app/views/users/calender.html.slim
+++ b/app/views/users/calender.html.slim
@@ -4,7 +4,7 @@
             h3 読みたいリスト
             table.table.table-hover
                 - @books.order(:sales_date).each do |book|
-                    - if book.sales_date > Date.today-30
+                    - if book.sales_date.present? && book.sales_date > Date.today-30
                         tr
                             td = book.sales_date
                             td = book.title


### PR DESCRIPTION
# カレンダー表示のエラー修正
- カレンダー表示時、本の発売日がnullの場合エラーとなるため、nullの場合処理しないよう修正