### PR TITLE
[add] devise-ユーザー退会処理を論理削除で実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,9 +1,3 @@
 class ApplicationController < ActionController::Base
-  before_action :configure_permitted_parameters, if: :devise_controller?
 
-  protected
-  # サインアップ時にnameとname_idの登録を許可する
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys:[:email, :name, :is_mail_send])
-  end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,9 +6,4 @@ class NotificationsController < ApplicationController
     end
   end
 
-  def destroy_all
-    @notifications = current_user.passive_notifications.destroy_all
-    redirect_to request.referer
-  end
-
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only:[:create]
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+  protected
+  # サインアップ時にnameとname_idの登録を許可する
+  def configure_sign_up_params
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:email, :name, :is_mail_send])
+  end
+
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  before_action :reject_deleted_user, only: [:create]
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+
+  protected
+  def reject_deleted_user
+    user = User.find_by(email: params[:user][:email])
+    if user
+      if user.valid_password?(params[:user][:password]) && user.is_deleted
+        redirect_to new_user_session_path
+        flash[:alert] = 'お客様は退会済みです。申し訳ございませんが、あらためて会員登録をお願いいたします。'
+      end
+    end
+  end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
   before_action :set_correct_user, only: [:edit, :update]
-  before_action :set_correct_canceluser, only: [:cancel]
+  before_action :set_correct_canceluser, only: [:cancel, :unsubscribe]
 
   def show
     @user = User.find(params[:id])
@@ -31,6 +31,9 @@ class UsersController < ApplicationController
   end
 
   def unsubscribe
+    @user.update(is_deleted: true)
+    reset_session
+    redirect_to root_path, notice: "退会処理が完了しました。ご利用いただきありがとうございました。"
   end
 
   private
@@ -42,6 +45,7 @@ class UsersController < ApplicationController
     @user = User.find(params[:id])
     redirect_to root_path unless @user == current_user
   end
+
   def set_correct_canceluser
     @user = User.find(params[:user_id])
     redirect_to root_path unless @user == current_user

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -5,9 +5,6 @@
     - notifications = notifications.where.not(id:notification.id)
 
 - if notifications.exists?
-    = link_to destroy_all_path, method: :delete do
-      i.fas.fa-trash style="color: black;"
-      h7 style="color: black;"全削除
     = render notifications
 - else
     p.text-center

--- a/app/views/users/cancel.html.slim
+++ b/app/views/users/cancel.html.slim
@@ -1,11 +1,11 @@
 .col-sm-8.mx-auto.my-5
-  h3.text-center.py-3.my-4
+  h2.text-center.py-3.my-4.bg-danger.text-white
     | 本当に退会しますか？
-    .text-center
-      p
-       | 退会すると、会員登録情報や<br>
-        これまでの購入履歴が閲覧できなくなります。
-        退会する場合は、「退会する」をクリックしてください。
+  .text-center
+    h4.bg-light.py-3
+     | 退会すると、会員登録情報や <br>
+      これまでの購入履歴が閲覧できなくなります。<br>
+      退会する場合は、「退会する」をクリックしてください。
 
     .text-center
       = link_to "退会しない", user_path(current_user), class: "btn btn-primary col-sm-2 p-2 mt-3"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
-  devise_for :users
+  # devise_for :users
+  devise_for :users, controllers: {
+    sessions: "users/sessions",
+    registrations: "users/registrations",
+  }
   root to: "homes#about"
   resources :users, only: [:show, :edit, :update] do
     get "follows" => "users#follows"
@@ -11,7 +15,6 @@ Rails.application.routes.draw do
     resource :relationships, only: [:create, :destroy]
   end
 
-
   resources :books, only: [:index, :show, :create] do
     resources :book_reads,  only: [:show, :create, :destroy, :update] do
       resources :read_comments,  only: [:create, :destroy]
@@ -21,9 +24,6 @@ Rails.application.routes.draw do
   end
   resources :timelines, only: [:index]
   resources :notifications, only: [:index]
-  delete "destroy_all" => "notifications#destroy_all"
-
-
   get "book/ranking" => "books#ranking"
 
 end


### PR DESCRIPTION
# ユーザー退会処理を実装
- ユーザー退会処理実装を論理削除で実装
- 退会するとis_deletedがtrueになる
- trueの場合は、ログインできなくなる
- サインインと会員登録で上記の処理が必要のため、deviseのコントローラーを作成
- routeにusers/deviseコントローラーを参照するよう修正