### PR TITLE
[Fix] raty-星増殖修正

### DIFF
--- a/app/views/book_reads/show.html.slim
+++ b/app/views/book_reads/show.html.slim
@@ -43,6 +43,7 @@
                     = @book_read.read_comments.count
 
           javascript:
+            $("#comment_rate_#{@book_read.id}").empty();
             $("#comment_rate_#{@book_read.id}").raty({
               size: 10,
               starOff: "#{asset_path('star-off.png')}",
@@ -50,7 +51,7 @@
               starHalf: "#{asset_path('star-half.png')}",
               half: true,
               readOnly: true,
-              score: #{@book_read.rate},
+              score: "#{@book_read.rate}",
             });
 
 

--- a/app/views/books/_ranking.html.slim
+++ b/app/views/books/_ranking.html.slim
@@ -35,6 +35,7 @@
         = image_tag book_rank.image_url.chomp("?_ex=200x200"), :width => '60%', class:"text-right ranking_book_jacket"
 
       javascript:
+        $("#rate_#{book_rank.id}").empty();
         $("#rate_#{book_rank.id}").raty({
           size: 20,
           starOff: "#{asset_path('star-off.png')}",

--- a/app/views/books/_read.html.slim
+++ b/app/views/books/_read.html.slim
@@ -35,7 +35,8 @@
               = link_to "削除する", book_book_read_path(book, book_read),  method: :delete, remote: true,  class: "btn btn-secondary", data: { disable_with: "送信中..." }
               = f.submit "編集する", class: "btn btn-primary", data: { disable_with: "送信中..." }
           javascript:
-            $('#star-edit').raty({
+            $("#star-edit").empty();
+            $("#star-edit").raty({
               size     : 36,
               starOff: "#{asset_path('star-off.png')}",
               starOn: "#{asset_path('star-on.png')}",

--- a/app/views/books/_review.html.slim
+++ b/app/views/books/_review.html.slim
@@ -36,6 +36,7 @@
                 i.fa.fa-comments コメント#{review.read_comments.count}
 
     javascript:
+      $("#rate_#{review.id}").empty();
       $("#rate_#{review.id}").raty({
         size: 10,
         starOff: "#{asset_path('star-off.png')}",

--- a/app/views/books/show.html.slim
+++ b/app/views/books/show.html.slim
@@ -46,6 +46,7 @@
   = render "review", reviews: @reviews
 
 javascript:
+  $("#avg_rate_#{@book.id}").empty();
   $("#avg_rate_#{@book.id}").raty({
     size: 10,
     starOff: "#{asset_path('star-off.png')}",

--- a/app/views/timelines/_timeline.html.slim
+++ b/app/views/timelines/_timeline.html.slim
@@ -62,6 +62,7 @@
                 i.fa.fa-comments コメント#{timeline.book_read.read_comments.count}
 
       javascript:
+        $("#rate_#{timeline.book_read.id}").empty();
         $("#rate_#{timeline.book_read.id}").raty({
           size: 10,
           starOff: "#{asset_path('star-off.png')}",

--- a/app/views/users/_read.html.slim
+++ b/app/views/users/_read.html.slim
@@ -46,6 +46,7 @@
             = image_tag book_read.book.image_url.chomp("?_ex=200x200"), :size => "270x355", class:"user_show_jacket"
 
       javascript:
+        $("#rate_#{book_read.id}").empty();
         $("#rate_#{book_read.id}").raty({
           size: 10,
           starOff: "#{asset_path('star-off.png')}",


### PR DESCRIPTION
# ブラウズバック時、ratyの星が増殖する減少を修正
- ブラウザバックする度に星が読み込まれることが、原因だった。
- ページ読み込み時に、星をリセットすることで対応

参考
https://qiita.com/hana_s_e_0925/items/1a72927b03c01229de07