### PR TITLE
ActiveStorage実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'jbuilder', '~> 2.5'
 # gem 'bcrypt', '~> 3.1.7'
 
 # Use ActiveStorage variant
-# gem 'mini_magick', '~> 4.8'
+gem 'mini_magick', '~> 4.8'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
@@ -92,3 +92,4 @@ gem 'aws-sdk-rails'
 gem 'whenever', require: false
 gem 'omniauth', '1.9.1'
 gem 'omniauth-twitter'
+gem 'image_processing', '~> 1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,9 @@ GEM
       domain_name (~> 0.5)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.1)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.2)
       activesupport (>= 5.0.0)
     jmespath (1.4.0)
@@ -305,6 +308,8 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.10.2)
+    ruby-vips (2.1.3)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     ruby_dep (1.5.0)
     rubyzip (2.3.2)
@@ -408,10 +413,12 @@ DEPENDENCIES
   faker
   font-awesome-sass (~> 5.13)
   html2slim
+  image_processing (~> 1.2)
   jbuilder (~> 2.5)
   jquery-rails
   kaminari (~> 1.2.1)
   listen (>= 3.0.5, < 3.2)
+  mini_magick (~> 4.8)
   mysql2
   omniauth (= 1.9.1)
   omniauth-twitter

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,7 +1,7 @@
 class NotificationsController < ApplicationController
   before_action :authenticate_user!
   def index
-    @notifications = current_user.passive_notifications.page(params[:page]).per(15)
+    @notifications = current_user.passive_notifications.page(params[:page]).per(10)
     @notifications.where(checked: false).each do |notification|
       notification.update_attributes(checked: true)
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,7 +37,7 @@ class UsersController < ApplicationController
 
   private
   def user_params
-    params.require(:user).permit(:name, :email, :is_mail_send, :introduction, :image)
+    params.require(:user).permit(:name, :email, :is_mail_send, :introduction, :profile_image)
   end
 
   def set_correct_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,7 +27,7 @@ class User < ApplicationRecord
   validates :email, presence: true
   validates :introduction, length: { maximum: 50 }
 
-  attachment :image
+  has_one_attached :profile_image
 
   # ゲストユーザーでログイン
   def self.guest

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,11 +23,12 @@ class User < ApplicationRecord
   # 通知を受信
   has_many :passive_notifications, class_name: "Notification", foreign_key: "visited_id", dependent: :destroy
 
+  has_one_attached :profile_image
+
   validates :name, presence: true, length: { maximum: 15 }
   validates :email, presence: true
   validates :introduction, length: { maximum: 50 }
-
-  has_one_attached :profile_image
+  validate :profile_image_size
 
   # ゲストユーザーでログイン
   def self.guest
@@ -94,6 +95,13 @@ class User < ApplicationRecord
   private
   def self.dummy_email(auth)
     "#{auth.uid}-#{auth.provider}@bookmarks.net"
+  end
+
+  def profile_image_size
+    if profile_image.attached? && profile_image.blob.byte_size > 1.megabytes
+      profile_image.purge
+      errors.add(:profile_image, "は5MB以内にしてください")
+    end
   end
 
 end

--- a/app/views/book_reads/_read_comments.html.slim
+++ b/app/views/book_reads/_read_comments.html.slim
@@ -4,7 +4,10 @@
       .flex-column
         .d-flex.flex-row.mb-1
           = link_to user_path(comment.user_id) do
-            = attachment_image_tag comment.user, :image, :fill, 50, 50, fallback:"noimage.jpg", size: "50x50", class: "rounded-circle"
+            - if comment.user.profile_image.attached?
+              = image_tag comment.user.profile_image.variant(combine_options:{gravity: :center, resize:"50x50^",crop:"50x50+0+0"}).processed, class: "rounded-circle"
+            - else
+              = image_tag image_url("noimage.jpg"), size:"50x50", class: "rounded-circle"
           .flex-column.ml-3
             = link_to comment.user.name, user_path(comment.user), class:"text-dark"
             .small.text-muted

--- a/app/views/book_reads/show.html.slim
+++ b/app/views/book_reads/show.html.slim
@@ -6,7 +6,10 @@
             .flex-column
               .d-flex.flex-row.mb-1
                 = link_to user_path(@user) do
-                  = attachment_image_tag @user, :image, :fill, 80, 80, fallback:"noimage.jpg", size: "80x80", class: "rounded-circle"
+                  - if @user.profile_image.attached?
+                    = image_tag @user.profile_image.variant(combine_options:{gravity: :center, resize:"80x80^",crop:"80x80+0+0"}).processed, class: "rounded-circle"
+                  - else
+                    = image_tag image_url("noimage.jpg"), size:"80x80", class: "rounded-circle"
                 strong.flex-column.ml-3
                   = link_to "#{@user.name}の感想・レビュー", book_book_read_path(@book, @book_read, user: @user), class:"text-dark"
                   .small.text-muted
@@ -59,7 +62,10 @@
       .bg-white.border
         = form_with model: ReadComment, url: book_book_read_read_comments_path(@book, @book_read), method: :post, remote: true, id:"book_read_comment_form", class:"form-inline" do |f|
           = link_to user_path(current_user) do
-            = attachment_image_tag current_user, :image, :fill, 80, 80, fallback:"noimage.jpg", size: "80x80", class: "rounded-circle m-2"
+            - if current_user.profile_image.attached?
+              = image_tag current_user.profile_image.variant(combine_options:{gravity: :center, resize:"80x80^",crop:"80x80+0+0"}).processed, class: "rounded-circle m-2"
+            - else
+              = image_tag image_url("noimage.jpg"), size:"80x80", class: "rounded-circle m-2"
           = f.text_area :comment, placeholder: "コメントする", class:"form-control form-control-sm w-75 ml-3"
           = f.submit "送信", class:"btn btn-primary mx-auto"
 

--- a/app/views/books/_review.html.slim
+++ b/app/views/books/_review.html.slim
@@ -10,7 +10,10 @@
           .flex-column
             .d-flex.flex-row.mb-1
               = link_to user_path(review.user_id) do
-                = attachment_image_tag review.user, :image, size: "50x50", fallback: "noimage.jpg", class: "rounded-circle"
+                - if review.user.profile_image.attached?
+                  = image_tag review.user.profile_image.variant(combine_options:{gravity: :center, resize:"50x50^",crop:"50x50+0+0"}).processed, class: "rounded-circle"
+                - else
+                  = image_tag image_url("noimage.jpg"), size:"50x50", class: "rounded-circle"
               strong.flex-column.ml-3
                 = link_to "#{review.user.name}の感想・レビュー", book_book_read_path(review.book_id, review, user: review.user), class:"text-dark"
                 .small.text-muted

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -1,4 +1,4 @@
-.container.mb-5
+.container
   .col-md-6.mx-auto.bg-white.shadow.p-3.mt-5
     h2.mb-4
       = t(".sign_in")

--- a/app/views/devise/shared/_error_messages.html.slim
+++ b/app/views/devise/shared/_error_messages.html.slim
@@ -4,7 +4,7 @@
       = I18n.t("errors.messages.not_saved",
         count: resource.errors.count,
         resource: resource.class.model_name.human.downcase)
-    ul.list-unstyled
+    ul.list-unstyled.alert.alert-danger
       - resource.errors.full_messages.each do |message|
         li
           = message

--- a/app/views/layouts/_error_messages.html.slim
+++ b/app/views/layouts/_error_messages.html.slim
@@ -1,6 +1,6 @@
-- if obj.errors.include?(column)
-  ul.error_explanation.list-unstyled
-    - obj.errors.full_messages_for(column).each do |message|
+- if obj.errors.any?
+  ul.error_explanation.list-unstyled.alert.alert-danger
+    - obj.errors.full_messages.each do |message|
       li.text-danger.small.mt-1.ml-4
         = message
 

--- a/app/views/notifications/_notification.html.slim
+++ b/app/views/notifications/_notification.html.slim
@@ -11,6 +11,10 @@
           .d-flex.flex-row.mb-1
             = link_to user_path(visitor) do
               = attachment_image_tag visitor, :image, size: "50x50", fallback: "noimage.jpg", class: "rounded-circle"
+              - if comment.user.profile_image.attached?
+                = image_tag comment.user.profile_image.variant(combine_options:{gravity: :center, resize:"50x50^",crop:"50x50+0+0"}).processed, class: "rounded-circle"
+              - else
+                = image_tag image_url("noimage.jpg"), size:"50x50", class: "rounded-circle"
             .flex-column.ml-3
               = link_to visitor.name, user_path(visitor), class:"text-dark"
               .small.text-muted
@@ -25,7 +29,10 @@
         .flex-column.mb-5.w-75
           .d-flex.flex-row.mb-1
             = link_to user_path(visitor) do
-              = attachment_image_tag visitor, :image, size: "50x50", fallback: "noimage.jpg", class: "rounded-circle"
+              - if visitor.profile_image.attached?
+                = image_tag visitor.profile_image.variant(combine_options:{gravity: :center, resize:"50x50^",crop:"50x50+0+0"}).processed, class: "rounded-circle"
+              - else
+                = image_tag image_url("noimage.jpg"), size:"50x50", class: "rounded-circle"
             .flex-column.ml-3
               = link_to visitor.name, user_path(visitor), class:"text-dark"
               .small.text-muted
@@ -44,7 +51,10 @@
         .flex-column.w-75
           .d-flex.flex-row.mb-4
             = link_to user_path(visitor) do
-              = attachment_image_tag visitor, :image, size: "50x50", fallback: "noimage.jpg", class: "rounded-circle"
+              - if visitor.profile_image.attached?
+                = image_tag visitor.profile_image.variant(combine_options:{gravity: :center, resize:"50x50^",crop:"50x50+0+0"}).processed, class: "rounded-circle"
+              - else
+                = image_tag image_url("noimage.jpg"), size:"50x50", class: "rounded-circle"
             .flex-column.ml-3
               = link_to visitor.name, user_path(visitor), class:"text-dark"
               .small.text-muted
@@ -69,7 +79,10 @@
         .flex-column.pb-5.w-75
           .d-flex.flex-row.mb-1
             = link_to user_path(visitor) do
-              = attachment_image_tag visitor, :image, size: "50x50", fallback: "noimage.jpg", class: "rounded-circle"
+              - if visitor.profile_image.attached?
+                = image_tag visitor.profile_image.variant(combine_options:{gravity: :center, resize:"50x50^",crop:"50x50+0+0"}).processed, class: "rounded-circle"
+              - else
+                = image_tag image_url("noimage.jpg"), size:"50x50", class: "rounded-circle"
             .flex-column.ml-3
               = link_to visitor.name, user_path(visitor), class:"text-dark"
               .small.text-muted

--- a/app/views/notifications/index.html.slim
+++ b/app/views/notifications/index.html.slim
@@ -14,6 +14,6 @@
 
   .row
     .mx-auto.my-5
-      = paginate @notifications
+      = paginate notifications
 
 

--- a/app/views/timelines/_timeline.html.slim
+++ b/app/views/timelines/_timeline.html.slim
@@ -8,7 +8,10 @@
         .flex-column
           .d-flex.flex-row.mb-1
             = link_to user_path(visitor) do
-              = attachment_image_tag visitor, :image, :fill, 50, 50, fallback:"noimage.jpg", size: "50x50", class: "rounded-circle"
+              - if visitor.profile_image.attached?
+                = image_tag visitor.profile_image.variant(combine_options:{gravity: :center, resize:"50x50^",crop:"50x50+0+0"}).processed, class: "rounded-circle"
+              - else
+                = image_tag image_url("noimage.jpg"), size:"50x50", class: "rounded-circle"
             .flex-column.ml-3
               = link_to visitor.name, user_path(visitor), class:"text-dark"
               .small.text-muted
@@ -25,7 +28,10 @@
           .flex-column
             .d-flex.flex-row.mb-1
               = link_to user_path(visitor) do
-                = attachment_image_tag visitor, :image, :fill, 50, 50, fallback:"noimage.jpg", size: "50x50", class: "rounded-circle"
+                - if visitor.profile_image.attached?
+                  = image_tag visitor.profile_image.variant(combine_options:{gravity: :center, resize:"50x50^",crop:"50x50+0+0"}).processed, class: "rounded-circle"
+                - else
+                  = image_tag image_url("noimage.jpg"), size:"50x50", class: "rounded-circle"
               strong.flex-column.ml-3
                 = link_to "#{visitor.name}の感想・レビュー", book_book_read_path(timeline.book_id, timeline.book_read_id, user: visited), class:"text-dark"
                 .small.text-muted

--- a/app/views/users/_follow.html.slim
+++ b/app/views/users/_follow.html.slim
@@ -3,7 +3,10 @@
     .bg-white.p-3.border.w-100.h-100
       .d-flex
         = link_to user_path(follow_user.id) do
-          = attachment_image_tag follow_user, :image, :fill, 80, 80, fallback:"noimage.jpg", size: "80x80", class: "rounded-circle shadow-sm mr-4"
+          - if follow_user.profile_image.attached?
+            = image_tag follow_user.profile_image.variant(combine_options:{gravity: :center, resize:"80x80^",crop:"80x80+0+0"}).processed, class: "rounded-circle shadow-sm mr-4"
+          - else
+            = image_tag image_url("noimage.jpg"), size:"80x80", class: "rounded-circle shadow-sm mr-4"
         .d-flex.flex-column
           strong.d-flex.flex-row
             = link_to follow_user.name, user_path(follow_user.id), class:"text-dark mr-3"

--- a/app/views/users/_follower.html.slim
+++ b/app/views/users/_follower.html.slim
@@ -3,7 +3,10 @@
     .bg-white.p-3.border.w-100.h-100
       .d-flex
         = link_to user_path(follower_user.id) do
-          = attachment_image_tag follower_user, :image, :fill, 80, 80, fallback:"noimage.jpg", size: "80x80", class: "rounded-circle shadow-sm mr-4"
+          - if follower_user.profile_image.attached?
+            = image_tag follower_user.profile_image.variant(combine_options:{gravity: :center, resize:"80x80^",crop:"80x80+0+0"}).processed, class: "rounded-circle shadow-sm mr-4"
+          - else
+            = image_tag image_url("noimage.jpg"), size:"80x80", class: "rounded-circle shadow-sm mr-4"
         .d-flex.flex-column
           strong.d-flex.flex-row
             = link_to follower_user.name, user_path(follower_user.id), class:"text-dark mr-3"

--- a/app/views/users/_read.html.slim
+++ b/app/views/users/_read.html.slim
@@ -43,7 +43,7 @@
               = book_read.created_at.strftime('%Y/%m/%d')
 
           = link_to book_path(book_read.book.id), local: true, class:"flex-auto text-right my-auto" do
-            = image_tag book_read.book.image_url.chomp("?_ex=200x200"), :size => "270x355", class:"user_show_jacket"
+            = image_tag book_read.book.image_url.chomp("?_ex=200x200"), :size => "245x355", class:"user_show_jacket"
 
       javascript:
         $("#rate_#{book_read.id}").empty();

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -3,11 +3,11 @@
     .col-md-12
       .bg-white.text-center.border.shadow.py-3
         h3 プロフィール編集
-    = render "layouts/error_messages", obj: @user, column: :name
   .row
     .col-md-12.text-center.mt-4
       .bg-white.py-5
         = form_with model: @user, local: true do |f|
+          = render "layouts/error_messages", obj: @user
           .d-inline-flex.user_edit_flex
             .d-block.mr-3.user_edit_jacket
               - if @user.profile_image.attached?

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -10,10 +10,13 @@
         = form_with model: @user, local: true do |f|
           .d-inline-flex.user_edit_flex
             .d-block.mr-3.user_edit_jacket
-              = attachment_image_tag @user, :image, :fill, 180, 180, fallback:"noimage.jpg", size: "180x180", class: "rounded-circle shadow-sm mr-4 mb-4"
+              - if @user.profile_image.attached?
+                = image_tag @user.profile_image.variant(combine_options:{gravity: :center, resize:"180x180^",crop:"180x180+0+0"}).processed, class: "rounded-circle shadow-sm mr-4 mb-4"
+              - else
+                = image_tag image_url("noimage.jpg"), size:"180x180", class: "rounded-circle shadow-sm mr-4 mb-4"
               br
               small
-                = f.attachment_field :image
+                = f.file_field :profile_image
 
             .d-block.user_edit_input
               .form-group

--- a/app/views/users/followers.html.slim
+++ b/app/views/users/followers.html.slim
@@ -1,2 +1,0 @@
-h1 Users#followers
-p Find me in app/views/users/followers.html.slim

--- a/app/views/users/follows.html.slim
+++ b/app/views/users/follows.html.slim
@@ -1,2 +1,0 @@
-h1 Users#follows
-p Find me in app/views/users/follows.html.slim

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -5,7 +5,11 @@
         .row.mt-5
           .col-md-8.col-sm-8
             .d-inline-flex.align-items-center
-              = attachment_image_tag @user, :image, :fill, 130, 130, fallback:"noimage.jpg", size: "130x130", class: "rounded-circle shadow-sm ml-4"
+              - if @user.profile_image.attached?
+                = image_tag @user.profile_image.variant(combine_options:{gravity: :center, resize:"130x130^",crop:"130x130+0+0"}).processed, class: "rounded-circle shadow-sm ml-4"
+              - else
+                = image_tag image_url("noimage.jpg"), size:"130x130", class: "rounded-circle shadow-sm ml-4"
+
               .d-block.ml-5
                 h3.user_show_name
                   = @user.name

--- a/db/migrate/20210902023558_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20210902023558_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,27 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,        null: false
+      t.string   :filename,   null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.bigint   :byte_size,  null: false
+      t.string   :checksum,   null: false
+      t.datetime :created_at, null: false
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20210902024035_removeimage_id_fromusers.rb
+++ b/db/migrate/20210902024035_removeimage_id_fromusers.rb
@@ -1,0 +1,5 @@
+class RemoveimageIdFromusers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :image_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,28 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_20_014759) do
+ActiveRecord::Schema.define(version: 2021_09_02_024035) do
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.integer "record_id", null: false
+    t.integer "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
 
   create_table "book_reads", force: :cascade do |t|
     t.integer "user_id"
@@ -116,7 +137,6 @@ ActiveRecord::Schema.define(version: 2021_08_20_014759) do
     t.datetime "remember_created_at"
     t.string "name", null: false
     t.text "introduction"
-    t.string "image_id"
     t.boolean "is_mail_send", default: false, null: false
     t.boolean "is_deleted", default: false, null: false
     t.string "confirmation_token"


### PR DESCRIPTION
# ActiveStorage実装
### 背景
refileが数年更新がなく、railsでActiveStorageが利用できるようになったため

### 変更箇所
- Userモデルの記述を変更
- Usersテーブルのimageカラムを削除
- ビューファイルの記述をimage_tagに変更
- 画像アップロードの独自バリデーションを実装(5MBまで)